### PR TITLE
Ajustes a la GUI, materiales y shader de ondas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -986,8 +986,7 @@
     "node_modules/three": {
       "version": "0.172.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
-      "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
-      "license": "MIT"
+      "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow=="
     },
     "node_modules/typescript": {
       "version": "5.6.3",
@@ -1080,7 +1079,6 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-glsl/-/vite-plugin-glsl-1.3.1.tgz",
       "integrity": "sha512-iClII8Idb9X0m6nS0YI2cWWXbBuT5EKKw5kXSAuRu4RJsNe4oypxKXE7jx0XMoyqij2s8WL0ZLfou801mpkREg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.0"
       },

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  shellHook = ''
+    npm install -g vite 
+    npm install three vite-plugin-glsl
+    npm install
+  '';
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,8 @@ class App {
       64,
     );
     // Create shader materials
-    const simpleWave = new SimpleWave(this.camera, gui);
+
+    const simpleWave = new SimpleWave(this.camera, gui, geometrySize);
     const blinnPhong = new BlinnPhong(this.camera, gui);
     const crt = new CRT(this.camera, gui, geometrySize);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,6 +113,11 @@ class App {
     this.mesh = new THREE.Mesh(this.geometry, this.shader.material);
     this.scene.add(this.mesh);
 
+    // This shader requires the position in the mesh so it can be interactive
+    if (this.shader instanceof SimpleWave) {
+      this.shader.setMesh(this.mesh);
+    }
+
     // Initialize
     this.onWindowResize();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,8 +62,8 @@ class App {
 
     // Adds Blinn-Phong cube
     // this.element = new BlinnPhong(this.camera, gui);
-    // this.element = new SimpleWave(this.camera, gui);
-    this.element = new CRT(this.camera, gui);
+    this.element = new SimpleWave(this.camera, gui);
+    // this.element = new CRT(this.camera, gui);
     this.scene.add(this.element.mesh);
 
     // Initialize

--- a/src/materials/blinnPhong.ts
+++ b/src/materials/blinnPhong.ts
@@ -7,9 +7,7 @@ import fragmentShader from "../shaders/blinnPhong/fragment.glsl";
 export class BlinnPhong {
   private camera: THREE.PerspectiveCamera;
   private defaultUniforms: any;
-  geometry: THREE.BoxGeometry;
   material: THREE.RawShaderMaterial;
-  mesh: THREE.Mesh;
   gui: GUI;
 
   constructor(camera: THREE.PerspectiveCamera, gui: GUI) {
@@ -26,12 +24,9 @@ export class BlinnPhong {
       shininess: 25.0,
       screenGamma: 2.2,
     };
-    this.geometry = new THREE.BoxGeometry(1, 1, 1, 32, 32, 32);
-    this.geometry.computeVertexNormals();
+
     this.material = this.createMaterial(this.defaultUniforms);
     this.gui = gui;
-    this.mesh = new THREE.Mesh(this.geometry, this.material);
-
     this.addUIControls();
   }
 
@@ -75,6 +70,9 @@ export class BlinnPhong {
         projectionMatrix: { value: this.camera.projectionMatrix },
         viewMatrix: { value: this.camera.matrixWorldInverse },
         modelMatrix: { value: new THREE.Matrix4() },
+        uResolution: {
+          value: new THREE.Vector2(window.innerWidth, window.innerHeight),
+        },
       },
       glslVersion: THREE.GLSL3,
     });
@@ -82,7 +80,7 @@ export class BlinnPhong {
   }
 
   private addUIControls() {
-    const specular = this.gui.addFolder("Specular");
+    const specular = this.gui.addFolder("Blinn-Phong Shader");
     const lightFolder = specular.addFolder("Light");
     const uniforms = this.defaultUniforms;
     lightFolder

--- a/src/materials/crt.ts
+++ b/src/materials/crt.ts
@@ -7,17 +7,15 @@ import fragmentShader from "../shaders/crt/fragment.glsl";
 export class CRT {
   private camera: THREE.PerspectiveCamera;
   private defaultUniforms: any;
-  geometry: THREE.PlaneGeometry;
+  private gui: GUI;
   material: THREE.RawShaderMaterial;
-  mesh: THREE.Mesh;
-  gui: GUI;
 
-  constructor(camera: THREE.PerspectiveCamera, gui: GUI) {
+  constructor(camera: THREE.PerspectiveCamera, gui: GUI, size: number) {
     this.camera = camera;
 
     // Default uniforms for shaders
     this.defaultUniforms = {
-      uSize: 4.0,
+      uSize: size,
       uFrequency: 400.0,
       uTime: 0.0,
       uSpeed: 2.5,
@@ -27,17 +25,8 @@ export class CRT {
       uVignette: 0.34,
     };
 
-    this.geometry = new THREE.PlaneGeometry(
-      this.defaultUniforms.uSize,
-      this.defaultUniforms.uSize,
-      64,
-      64,
-    );
-    this.geometry.computeVertexNormals();
     this.material = this.createMaterial();
     this.gui = gui;
-    this.mesh = new THREE.Mesh(this.geometry, this.material);
-
     this.addUIControls();
   }
 
@@ -55,7 +44,7 @@ export class CRT {
         uResolution: {
           value: new THREE.Vector2(window.innerWidth, window.innerHeight),
         },
-
+        // Custom uniforms
         uSize: { value: this.defaultUniforms.uSize },
         uTexture: { value: textureLoader.load("smb.png") },
         uFrequency: { value: this.defaultUniforms.uFrequency },
@@ -73,35 +62,38 @@ export class CRT {
 
   private addUIControls() {
     const uniforms = this.defaultUniforms;
-    this.gui
+    const shaderFolder = this.gui.addFolder("CRT Shader");
+    const scanLinesFolder = shaderFolder.addFolder("Scan Lines");
+    scanLinesFolder
       .add(uniforms, "uFrequency", 0.0, 1000.0)
       .name("Frequency")
       .onChange(
         () => (this.material.uniforms.uFrequency.value = uniforms.uFrequency),
       );
-    this.gui
+    scanLinesFolder
       .add(uniforms, "uSpeed", 0.0, 10.0)
       .name("Speed")
       .onChange(() => (this.material.uniforms.uSpeed.value = uniforms.uSpeed));
-    this.gui
+    const geometryFolder = shaderFolder.addFolder("Geometry");
+    geometryFolder
       .add(uniforms, "uCurvature", 0.0, 5.0)
       .name("Curvature")
       .onChange(
         () => (this.material.uniforms.uCurvature.value = uniforms.uCurvature),
       );
-    this.gui
+    geometryFolder
       .add(uniforms, "uRadius", 0, 1.0)
       .name("Radius")
       .onChange(
         () => (this.material.uniforms.uRadius.value = uniforms.uRadius),
       );
-    this.gui
+    geometryFolder
       .add(uniforms, "uBrightness", 0.0, 5.0)
       .name("Brightness")
       .onChange(
         () => (this.material.uniforms.uBrightness.value = uniforms.uBrightness),
       );
-    this.gui
+    geometryFolder
       .add(uniforms, "uVignette", 0.0, 1.0)
       .name("Vignette")
       .onChange(

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -55,7 +55,7 @@ export class SimpleWave {
   }
 
   private addUIControls() {
-    const generalFolder = this.gui.addFolder("General");
+    const generalFolder = this.gui.addFolder("Simple Wave Shader");
     const uniforms = this.defaultUniforms;
 
     generalFolder

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -101,8 +101,9 @@ export class SimpleWave {
   }
 
   private addUIControls(geometrySize: number) {
-    const generalFolder = this.gui.addFolder("Simple Wave Shader");
-    const toggleFolder = this.gui.addFolder("Wave Toggle Variations (Seconds)");
+    const waves = this.gui.addFolder("Simple Wave Shader");
+    const generalFolder = waves.addFolder("General");
+    const toggleFolder = waves.addFolder("Wave Toggle Variations (Seconds)");
     const uniforms = this.defaultUniforms;
 
     generalFolder
@@ -144,7 +145,7 @@ export class SimpleWave {
     );
     toggleFolder
       .add(uniforms, "wavePropagationDelta", 0.0, geometrySize)
-      .name("Wave Propagation")
+      .name("Propagation Speed")
       .onChange(() => (this.material.uniforms.wavePropagationDelta.value = uniforms.wavePropagationDelta)
     );
     

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -19,6 +19,8 @@ export class SimpleWave {
     // Default uniforms for shaders
     this.defaultUniforms = {
       waveFrequency: 10.0,
+      waveSpeed: 1.0,
+      waveAmplitude: 0.1,
       u_time: 0.0,
       resolution: new THREE.Vector2(window.innerWidth, window.innerHeight),
     };
@@ -38,6 +40,8 @@ export class SimpleWave {
       fragmentShader,
       uniforms: {
         waveFrequency: { value: uniforms.waveFrequency },
+        waveSpeed: { value: uniforms.waveSpeed },
+        waveAmplitude: { value: uniforms.waveAmplitude },
         uTime: { value: uniforms.u_time },
         uResolution: { value: uniforms.resolution},
         projectionMatrix: { value: this.camera.projectionMatrix },
@@ -58,6 +62,16 @@ export class SimpleWave {
       .name("Frequency")
       .onChange(
         () => (this.material.uniforms.waveFrequency.value = uniforms.waveFrequency),
+      );
+    generalFolder
+      .add(uniforms, "waveSpeed", 0.0, 100.0)
+      .name("Speed")
+      .onChange(() => (this.material.uniforms.waveSpeed.value = uniforms.waveSpeed)
+      );
+    generalFolder
+      .add(uniforms, "waveAmplitude", 0.0, 1.0)
+      .name("Amplitude")
+      .onChange(() => (this.material.uniforms.waveAmplitude.value = uniforms.waveAmplitude),
       );
   }
 

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -23,9 +23,13 @@ export class SimpleWave {
     this.defaultUniforms = {
       waveFrequency: 10.0,
       waveSpeed: 1.0,
-      waveAmplitude: 0.1,
+      waveMaxAmplitude: 0.1,
+      amplitudeDelta: 0.0,
+      toggleTime: 0.0,
       displacement: 0.0,
       waveEnabled: true,
+      waveReach: geometrySize,
+      wavePropagationDelta: 0.0,
       u_time: 0.0,
       resolution: new THREE.Vector2(window.innerWidth, window.innerHeight),
     };
@@ -66,6 +70,7 @@ export class SimpleWave {
     document.addEventListener("keydown", (event) => {
       if (event.key === " ") {
         this.material.uniforms.waveEnabled.value = !this.material.uniforms.waveEnabled.value;
+        this.material.uniforms.toggleTime.value = this.material.uniforms.uTime.value;
       }
     });
   }
@@ -77,9 +82,13 @@ export class SimpleWave {
       uniforms: {
         waveFrequency: { value: uniforms.waveFrequency },
         waveSpeed: { value: uniforms.waveSpeed },
-        waveAmplitude: { value: uniforms.waveAmplitude },
+        waveMaxAmplitude: { value: uniforms.waveMaxAmplitude },
         displacement: { value: uniforms.displacement },
         waveEnabled: { value: uniforms.waveEnabled },
+        waveReach: { value: uniforms.waveReach },
+        wavePropagationDelta: { value: uniforms.wavePropagationDelta },
+        amplitudeDelta: { value: uniforms.amplitudeDelta },
+        toggleTime: { value: uniforms.toggleTime },
         uTime: { value: uniforms.u_time },
         uResolution: { value: uniforms.resolution},
         projectionMatrix: { value: this.camera.projectionMatrix },
@@ -93,6 +102,7 @@ export class SimpleWave {
 
   private addUIControls(geometrySize: number) {
     const generalFolder = this.gui.addFolder("Simple Wave Shader");
+    const toggleFolder = this.gui.addFolder("Wave Toggle Variations (Seconds)");
     const uniforms = this.defaultUniforms;
 
     generalFolder
@@ -107,15 +117,37 @@ export class SimpleWave {
       .onChange(() => (this.material.uniforms.waveSpeed.value = uniforms.waveSpeed)
       );
     generalFolder
-      .add(uniforms, "waveAmplitude", 0.0, 1.0)
+      .add(uniforms, "waveMaxAmplitude", 0.0, 1.0)
       .name("Amplitude")
-      .onChange(() => (this.material.uniforms.waveAmplitude.value = uniforms.waveAmplitude),
+      .onChange(() => (this.material.uniforms.waveMaxAmplitude.value = uniforms.waveMaxAmplitude),
       );
     generalFolder
       .add(uniforms, "displacement", -0.5 * geometrySize, 0.5 * geometrySize)
       .name("Displacement")
       .onChange(() => (this.material.uniforms.displacement.value = uniforms.displacement)
     );
+    generalFolder
+      .add(uniforms, "waveReach", 0.0, geometrySize)
+      .name("Wave Reach")
+      .onChange(() => (this.material.uniforms.waveReach.value = uniforms.waveReach)
+    );
+
+    toggleFolder
+      .add(uniforms, "waveEnabled")
+      .name("Wave Enabled (Space)")
+      .onChange(() => (this.material.uniforms.waveEnabled.value = uniforms.waveEnabled)
+    );
+    toggleFolder
+      .add(uniforms, "amplitudeDelta", 0.0, 5.0)
+      .name("Amplitude")
+      .onChange(() => (this.material.uniforms.amplitudeDelta.value = uniforms.amplitudeDelta)
+    );
+    toggleFolder
+      .add(uniforms, "wavePropagationDelta", 0.0, geometrySize)
+      .name("Wave Propagation")
+      .onChange(() => (this.material.uniforms.wavePropagationDelta.value = uniforms.wavePropagationDelta)
+    );
+    
   }
 
   updateTime(elapsedTime: number) {

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -6,6 +6,7 @@ import fragmentShader from "../shaders/simpleWave/fragment.glsl";
 
 export class SimpleWave {
   private camera: THREE.PerspectiveCamera;
+  private geometrySize: number;
   private defaultUniforms: any;
   clock: THREE.Clock;
 //  geometry: THREE.PlaneGeometry;
@@ -15,9 +16,9 @@ export class SimpleWave {
   raycaster = new THREE.Raycaster();
   mouse = new THREE.Vector2();
 
-  constructor(camera: THREE.PerspectiveCamera, gui: GUI){
+  constructor(camera: THREE.PerspectiveCamera, gui: GUI, geometrySize: number) {
     this.camera = camera;
-
+    this.geometrySize = geometrySize;
     // Default uniforms for shaders
     this.defaultUniforms = {
       waveFrequency: 10.0,
@@ -32,7 +33,7 @@ export class SimpleWave {
     this.gui = gui;
     this.clock = new THREE.Clock()
 
-    this.addUIControls();
+    this.addUIControls(this.geometrySize);
 
     document.addEventListener("click", (event) => {
 
@@ -43,10 +44,8 @@ export class SimpleWave {
 
       if (this.mesh) {
       const intersects = this.raycaster.intersectObjects([this.mesh]);
-      console.log(intersects);
 
       if (intersects.length > 0) {
-        console.log("Clicked on mesh");
         
         const intersectionPoint = intersects[0].point;
         // converting intersection point to mesh local space
@@ -58,14 +57,16 @@ export class SimpleWave {
           localPoint.x / scale.x,
           localPoint.y / scale.y,
         );
-        console.log("Scaled Local Point X:", scaledLocalPoint.x);
         this.material.uniforms.displacement.value = scaledLocalPoint.x;
       }
 
+      }
+    });
 
-      this.material.uniforms.waveEnabled.value = !this.material.uniforms.waveEnabled.value;
-      console.log("Wave Enabled:", this.material.uniforms.waveEnabled.value);
-    }
+    document.addEventListener("keydown", (event) => {
+      if (event.key === " ") {
+        this.material.uniforms.waveEnabled.value = !this.material.uniforms.waveEnabled.value;
+      }
     });
   }
 
@@ -90,7 +91,7 @@ export class SimpleWave {
     return material;
   }
 
-  private addUIControls() {
+  private addUIControls(geometrySize: number) {
     const generalFolder = this.gui.addFolder("Simple Wave Shader");
     const uniforms = this.defaultUniforms;
 
@@ -111,10 +112,10 @@ export class SimpleWave {
       .onChange(() => (this.material.uniforms.waveAmplitude.value = uniforms.waveAmplitude),
       );
     generalFolder
-      .add(uniforms, "displacement", -0.5, 0.5)
+      .add(uniforms, "displacement", -0.5 * geometrySize, 0.5 * geometrySize)
       .name("Displacement")
-      .onChange(() => (this.material.uniforms.displacement.value = uniforms.displacement),
-      );
+      .onChange(() => (this.material.uniforms.displacement.value = uniforms.displacement)
+    );
   }
 
   updateTime(elapsedTime: number) {

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -8,7 +8,8 @@ export class SimpleWave {
   private camera: THREE.PerspectiveCamera;
   private defaultUniforms: any;
   private clock : THREE.Clock;
-  geometry: THREE.PlaneGeometry
+//  geometry: THREE.PlaneGeometry;
+  geometry: THREE.BoxGeometry;
   material: THREE.RawShaderMaterial;
   mesh: THREE.Mesh;
   gui: GUI;
@@ -24,7 +25,7 @@ export class SimpleWave {
       u_time: 0.0,
       resolution: new THREE.Vector2(window.innerWidth, window.innerHeight),
     };
-    this.geometry = new THREE.PlaneGeometry(1, 1, 32, 32);
+    this.geometry = new THREE.BoxGeometry(1, 1, 1, 32, 32, 32);
     this.geometry.computeVertexNormals();
     this.material = this.createMaterial(this.defaultUniforms);
     this.gui = gui;

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -7,12 +7,14 @@ import fragmentShader from "../shaders/simpleWave/fragment.glsl";
 export class SimpleWave {
   private camera: THREE.PerspectiveCamera;
   private defaultUniforms: any;
-  private clock : THREE.Clock;
+  clock: THREE.Clock;
 //  geometry: THREE.PlaneGeometry;
   geometry: THREE.BoxGeometry;
   material: THREE.RawShaderMaterial;
   mesh: THREE.Mesh;
   gui: GUI;
+  raycaster = new THREE.Raycaster();
+  mouse = new THREE.Vector2();
 
   constructor(camera: THREE.PerspectiveCamera, gui: GUI) {
     this.camera = camera;
@@ -23,6 +25,7 @@ export class SimpleWave {
       waveSpeed: 1.0,
       waveAmplitude: 0.1,
       displacement: 0.0,
+      waveEnabled: true,
       u_time: 0.0,
       resolution: new THREE.Vector2(window.innerWidth, window.innerHeight),
     };
@@ -34,6 +37,24 @@ export class SimpleWave {
     this.clock = new THREE.Clock()
 
     this.addUIControls();
+    document.addEventListener("click", (event) => {
+
+      this.mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+      this.mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+      
+      this.raycaster.setFromCamera(this.mouse, this.camera);
+      const intersects = this.raycaster.intersectObjects([this.mesh]);
+
+      if (intersects.length > 0) {
+        console.log("Clicked on mesh");
+
+        const intersectionPoint = intersects[0].point;
+        this.material.uniforms.displacement.value = intersectionPoint.x;
+      }
+
+
+      this.material.uniforms.waveEnabled.value = !this.material.uniforms.waveEnabled.value;
+    });
   }
 
   private createMaterial(uniforms: any): THREE.RawShaderMaterial {
@@ -45,6 +66,7 @@ export class SimpleWave {
         waveSpeed: { value: uniforms.waveSpeed },
         waveAmplitude: { value: uniforms.waveAmplitude },
         displacement: { value: uniforms.displacement },
+        waveEnabled: { value: uniforms.waveEnabled },
         uTime: { value: uniforms.u_time },
         uResolution: { value: uniforms.resolution},
         projectionMatrix: { value: this.camera.projectionMatrix },

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -7,6 +7,7 @@ import fragmentShader from "../shaders/simpleWave/fragment.glsl";
 export class SimpleWave {
   private camera: THREE.PerspectiveCamera;
   private defaultUniforms: any;
+  private clock : THREE.Clock;
   geometry: THREE.PlaneGeometry
   material: THREE.RawShaderMaterial;
   mesh: THREE.Mesh;
@@ -26,6 +27,7 @@ export class SimpleWave {
     this.material = this.createMaterial(this.defaultUniforms);
     this.gui = gui;
     this.mesh = new THREE.Mesh(this.geometry, this.material);
+    this.clock = new THREE.Clock()
 
     this.addUIControls();
   }
@@ -36,8 +38,8 @@ export class SimpleWave {
       fragmentShader,
       uniforms: {
         waveFrequency: { value: uniforms.waveFrequency },
-        u_time: { value: uniforms.u_time },
-        u_resolution: { value: uniforms.resolution},
+        uTime: { value: uniforms.u_time },
+        uResolution: { value: uniforms.resolution},
         projectionMatrix: { value: this.camera.projectionMatrix },
         viewMatrix: { value: this.camera.matrixWorldInverse },
         modelMatrix: { value: new THREE.Matrix4() },
@@ -53,13 +55,13 @@ export class SimpleWave {
 
     generalFolder
       .add(uniforms, "waveFrequency", 0.0, 100.0)
-      .name("Wave Frequency")
+      .name("Frequency")
       .onChange(
         () => (this.material.uniforms.waveFrequency.value = uniforms.waveFrequency),
       );
   }
 
   updateTime(elapsedTime: number) {
-    this.material.uniforms.u_time.value = elapsedTime;
+    this.material.uniforms.uTime.value = elapsedTime;
   }
 }

--- a/src/materials/simpleWave.ts
+++ b/src/materials/simpleWave.ts
@@ -22,6 +22,7 @@ export class SimpleWave {
       waveFrequency: 10.0,
       waveSpeed: 1.0,
       waveAmplitude: 0.1,
+      displacement: 0.0,
       u_time: 0.0,
       resolution: new THREE.Vector2(window.innerWidth, window.innerHeight),
     };
@@ -43,6 +44,7 @@ export class SimpleWave {
         waveFrequency: { value: uniforms.waveFrequency },
         waveSpeed: { value: uniforms.waveSpeed },
         waveAmplitude: { value: uniforms.waveAmplitude },
+        displacement: { value: uniforms.displacement },
         uTime: { value: uniforms.u_time },
         uResolution: { value: uniforms.resolution},
         projectionMatrix: { value: this.camera.projectionMatrix },
@@ -73,6 +75,11 @@ export class SimpleWave {
       .add(uniforms, "waveAmplitude", 0.0, 1.0)
       .name("Amplitude")
       .onChange(() => (this.material.uniforms.waveAmplitude.value = uniforms.waveAmplitude),
+      );
+    generalFolder
+      .add(uniforms, "displacement", -0.5, 0.5)
+      .name("Displacement")
+      .onChange(() => (this.material.uniforms.displacement.value = uniforms.displacement),
       );
   }
 

--- a/src/shaders/simpleWave/fragment.glsl
+++ b/src/shaders/simpleWave/fragment.glsl
@@ -1,4 +1,4 @@
-precision highp float;
+precision mediump float;
 
 uniform float uTime;
 uniform vec2 uResolution;
@@ -64,11 +64,11 @@ void main() {
   
   vec2 size = vec2(1.1f, 0.3f);  
 
-  float waveDirection = sign(uv.y);
+  vec2 waveDirection = vec2(0.0f, 1.0f);
 
   // flag colors (red is base)
-
-  vec2 blueOffset = vec2(0.0f, v_height * PROPORTION * waveDirection);
+  float displacement = v_height * dot(waveDirection, uv);
+  vec2 blueOffset = vec2(0.0f, displacement * 0.6);
   float distanceToBlue = sdfBox(blueOffset, uv, size / SIZE_PROPORTION);
   
   vec2 yellowOffset = vec2(0.0f, 3.0f * PROPORTION);
@@ -94,7 +94,7 @@ void main() {
     
     // star locations relative to center (parabolic function in y)
     float xOffset =  - 0.16 + float(i) * 0.045; // X offset
-    float yOffset = 0.035 - pow(float(i) - 3.5,2.0) * 0.005 + v_height * 0.3; 
+    float yOffset = 0.035 - pow(float(i) - 3.5,2.0) * 0.005 + v_height * 0.08; 
     starOffsets[i] = vec2(xOffset, yOffset);
     
     // calculate sdf and set color

--- a/src/shaders/simpleWave/fragment.glsl
+++ b/src/shaders/simpleWave/fragment.glsl
@@ -1,7 +1,7 @@
 precision highp float;
 
-uniform float u_time;
-uniform vec2 u_resolution;
+uniform float uTime;
+uniform vec2 uResolution;
 out vec4 fragColor;
 
 in float v_height;
@@ -58,7 +58,7 @@ void main() {
 
   // step 1 - show swizzling
   // swizzling:
-  vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+  vec2 uv = gl_FragCoord.xy / uResolution.xy;
   // conversion to [-1, 1] interval
   uv = uv * 2.0f - 1.0f;
   

--- a/src/shaders/simpleWave/vertex.glsl
+++ b/src/shaders/simpleWave/vertex.glsl
@@ -9,6 +9,7 @@ uniform float uTime;
 uniform float waveFrequency;
 uniform float waveAmplitude;
 uniform float waveSpeed;
+uniform float displacement;
 
 // - attributes
 in vec3 position;
@@ -29,9 +30,16 @@ vec4 clipSpaceTransform(vec4 modelPosition) {
 
 void main() {
 
-  // attribute handling with custom uniform (time)
   vec4 modelPosition = modelMatrix * vec4(position, 1.0);
-  v_height = sin(modelPosition.x * waveFrequency + uTime * waveSpeed) * waveAmplitude;
+  
+  // wave simmetry operations (dont fix if its not broken)
+  // this prevents from wave flattening in the transition for the symmetry point
+  float transitionSmoothness = 0.0;
+  float sign = smoothstep(-transitionSmoothness, transitionSmoothness, displacement - modelPosition.x ) * 2.0 - 1.0;
+  
+  
+  // attribute handling with custom uniform (time)
+  v_height = sign * sin((modelPosition.x - displacement) * waveFrequency + sign * uTime * waveSpeed) * waveAmplitude;
   modelPosition.z += v_height;
   vec4 viewPosition = clipSpaceTransform(modelPosition);
 

--- a/src/shaders/simpleWave/vertex.glsl
+++ b/src/shaders/simpleWave/vertex.glsl
@@ -10,6 +10,7 @@ uniform float waveFrequency;
 uniform float waveAmplitude;
 uniform float waveSpeed;
 uniform float displacement;
+uniform bool waveEnabled;
 
 // - attributes
 in vec3 position;
@@ -32,15 +33,21 @@ void main() {
 
   vec4 modelPosition = modelMatrix * vec4(position, 1.0);
   
+ if (waveEnabled) { 
+  
   // wave simmetry operations (dont fix if its not broken)
   // this prevents from wave flattening in the transition for the symmetry point
-  float transitionSmoothness = 0.0;
-  float sign = smoothstep(-transitionSmoothness, transitionSmoothness, displacement - modelPosition.x ) * 2.0 - 1.0;
+    float transitionSmoothness = 0.0;
+    float sign = smoothstep(-transitionSmoothness, transitionSmoothness, displacement - modelPosition.x ) * 2.0 - 1.0;
   
   
   // attribute handling with custom uniform (time)
-  v_height = sign * sin((modelPosition.x - displacement) * waveFrequency + sign * uTime * waveSpeed) * waveAmplitude;
-  modelPosition.z += v_height;
+    v_height = sign * sin((modelPosition.x - displacement) * waveFrequency + sign * uTime * waveSpeed) * waveAmplitude;
+    modelPosition.z += v_height;
+  }
+  else {
+    v_height = 0.0;
+  }
   vec4 viewPosition = clipSpaceTransform(modelPosition);
 
   v_uv = uv;

--- a/src/shaders/simpleWave/vertex.glsl
+++ b/src/shaders/simpleWave/vertex.glsl
@@ -7,17 +7,21 @@ uniform mat4 viewMatrix;
 // - custom uniforms
 uniform float uTime;
 uniform float waveFrequency;
-uniform float waveAmplitude;
+uniform float waveMaxAmplitude;
 uniform float waveSpeed;
 uniform float displacement;
+
 uniform bool waveEnabled;
+uniform float amplitudeDelta;
+uniform float wavePropagationDelta;
+
+uniform float toggleTime;
+uniform float waveReach;
 
 // - attributes
 in vec3 position;
 in vec3 normal;
 in vec2 uv;
-// - custom
-in float a_random;
 
 // - varying
 out float v_random;
@@ -31,27 +35,42 @@ vec4 clipSpaceTransform(vec4 modelPosition) {
 
 void main() {
 
+  float waveAmplitude = 0.0; // Initialize waveAmplitude to 0.0
+  float toggleElapsedTime = uTime - toggleTime;
   vec4 modelPosition = modelMatrix * vec4(position, 1.0);
   
- if (waveEnabled) { 
-  
-  // wave simmetry operations (dont fix if its not broken)
+  if (waveEnabled) { 
+    waveAmplitude = min(toggleElapsedTime * (waveMaxAmplitude / amplitudeDelta), waveMaxAmplitude);
+  } else {
+    waveAmplitude = max(waveMaxAmplitude - (toggleElapsedTime * (waveMaxAmplitude / amplitudeDelta)), 0.0);
+  }
+
+  float wavePropagation;
+  if (waveEnabled) { 
+    wavePropagation = min(toggleElapsedTime * (waveReach / wavePropagationDelta), waveReach);
+  } else {
+    wavePropagation = max(waveReach - (toggleElapsedTime * (waveReach / wavePropagationDelta)), 0.0);
+  }
+
+  float distanceToDisplacement = abs(displacement - modelPosition.x);
+
+  if (distanceToDisplacement <= wavePropagation || wavePropagationDelta == 0.0) {
+    // wave symmetry operations (dont fix if its not broken)
   // this prevents from wave flattening in the transition for the symmetry point
-    float transitionSmoothness = 0.0;
-    float sign = smoothstep(-transitionSmoothness, transitionSmoothness, displacement - modelPosition.x ) * 2.0 - 1.0;
-  
+  float transitionSmoothness = 0.0;
+  float sign = smoothstep(-transitionSmoothness, transitionSmoothness, displacement - modelPosition.x ) * 2.0 - 1.0;
   
   // attribute handling with custom uniform (time)
-    v_height = sign * sin((modelPosition.x - displacement) * waveFrequency + sign * uTime * waveSpeed) * waveAmplitude;
-    modelPosition.z += v_height;
-  }
-  else {
+  v_height = sign * sin((modelPosition.x - displacement) * waveFrequency + sign * uTime * waveSpeed) * waveAmplitude;
+  } else {
     v_height = 0.0;
   }
+
+  modelPosition.z += v_height;
+  
   vec4 viewPosition = clipSpaceTransform(modelPosition);
 
   v_uv = uv;
 
   gl_Position = viewPosition;
 }
-

--- a/src/shaders/simpleWave/vertex.glsl
+++ b/src/shaders/simpleWave/vertex.glsl
@@ -5,8 +5,10 @@ uniform mat4 projectionMatrix;
 uniform mat4 modelMatrix;
 uniform mat4 viewMatrix;
 // - custom uniforms
-uniform float u_time;
+uniform float uTime;
 uniform float waveFrequency;
+uniform float waveAmplitude;
+uniform float waveSpeed;
 
 // - attributes
 in vec3 position;
@@ -29,7 +31,7 @@ void main() {
 
   // attribute handling with custom uniform (time)
   vec4 modelPosition = modelMatrix * vec4(position, 1.0);
-  v_height = sin(modelPosition.x * waveFrequency + u_time * 1.0) * 0.1;
+  v_height = sin(modelPosition.x * waveFrequency + uTime * 1.0) * 0.1;
   modelPosition.z += v_height;
   vec4 viewPosition = clipSpaceTransform(modelPosition);
 

--- a/src/shaders/simpleWave/vertex.glsl
+++ b/src/shaders/simpleWave/vertex.glsl
@@ -31,7 +31,7 @@ void main() {
 
   // attribute handling with custom uniform (time)
   vec4 modelPosition = modelMatrix * vec4(position, 1.0);
-  v_height = sin(modelPosition.x * waveFrequency + uTime * 1.0) * 0.1;
+  v_height = sin(modelPosition.x * waveFrequency + uTime * waveSpeed) * waveAmplitude;
   modelPosition.z += v_height;
   vec4 viewPosition = clipSpaceTransform(modelPosition);
 


### PR DESCRIPTION
Integra cambios hechos previamente para separar la geometria de las clases de los shaders, ademas agrega ajustes y nuevos parametros a el shader de ondas.

![image](https://github.com/user-attachments/assets/9545454c-691f-47a2-98c5-063bb38842ab)

![image](https://github.com/user-attachments/assets/5da11a39-3321-4d26-972b-562f93a8c3fe)

![image](https://github.com/user-attachments/assets/e51dd06f-fa8b-4fe2-803d-bca7a1dfe0b5)

(ninguna geometria fue lastimada durante la creacion de este shader)